### PR TITLE
Speed up deserialization using socket.onread

### DIFF
--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -387,10 +387,19 @@ class SubscriberImpl extends EventEmitter {
   }
 
   _handleTcpTopicRequestResponse(resp, nodeUri){
-    let info = resp[2];
-    let port = info[2];
-    let address = info[1];
-    let socket = new TCPSocket();
+    const info = resp[2];
+    const port = info[2];
+    const address = info[1];
+    const socket = new TCPSocket({
+      onread: {
+        // Using this onread callback instead of .pipe() is more CPU efficient
+        buffer: Buffer.allocUnsafe(10 * 2**20), // MB
+        callback: (bytes, buf) => {
+          socket.$deserializer && socket.$deserializer.write(buf.subarray(0,bytes));
+        }
+      }
+    });
+
     socket.name = address + ':' + port;
     socket.nodeUri = nodeUri;
 
@@ -421,9 +430,9 @@ class SubscriberImpl extends EventEmitter {
       this._log.debug('Subscriber on ' + this.getTopic() + ' connected to publisher at ' + address + ':' + port);
       socket.write(this._createTcprosHandshake());
     });
+
     let deserializer = new DeserializeStream();
     socket.$deserializer = deserializer;
-    socket.pipe(deserializer);
 
     // cache client in "pending" map.
     // It's not validated yet so we don't want it to show up as a client.

--- a/src/utils/serialization_utils.js
+++ b/src/utils/serialization_utils.js
@@ -37,15 +37,19 @@ class DeserializeStream extends Transform  {
     // for the next message we'll need to deserialize
     this._inBody = false;
 
-    // track how many bytes of this message we've received so far
-    this._messageConsumed = 0;
-
     // how long this message will be
     this._messageLen = -1;
 
+    // buffer for holding the length of the message
+    this._messageSizeBuffer = Buffer.allocUnsafe(4);
+    // Number of bytes of the length field have we received so far for this message
+    this._messageSizeBufferReceived = 0;
+
     // as bytes of this message arrive, store them in this
     // buffer until we have the whole thing
-    this._messageBuffer = [];
+    this._messageBuffer = Buffer.allocUnsafe(1000); // initial allocation
+    // Number of bytes received so far for this message
+    this._messageBufferReceived = 0;
 
     // TODO: These are specific to parsing a service response...
     //   don't use them everywhere
@@ -61,27 +65,26 @@ class DeserializeStream extends Transform  {
 
     while (pos < chunkLen) {
       if (this._inBody) {
-        let messageRemaining = this._messageLen - this._messageConsumed;
+        let messageRemaining = this._messageLen - this._messageBufferReceived;
 
         // if the chunk is longer than the amount of the message we have left
         // just pull off what we need
         if (chunkLen >= messageRemaining + pos) {
-          let slice = chunk.slice(pos, pos + messageRemaining);
-          this._messageBuffer.push(slice);
-          let concatBuf = Buffer.concat(this._messageBuffer, this._messageLen);
-          this.emitMessage(concatBuf);
+          chunk.copy(this._messageBuffer, this._messageBufferReceived,
+            pos, pos + messageRemaining);
 
-          // message finished, reset
-          this._messageBuffer = [];
+          // message finished, emit and reset
+          this.emitMessage(this._messageBuffer.slice(0,this._messageLen));
           pos += messageRemaining;
           this._inBody = false;
-          this._messageConsumed = 0;
+          this._messageBufferReceived = 0;
+          this._messageSizeBufferReceived = 0;
         }
         else {
           // rest of the chunk does not complete the message
           // cache it and move on
-          this._messageBuffer.push(chunk.slice(pos));
-          this._messageConsumed += chunkLen - pos;
+          chunk.copy(this._messageBuffer, this._messageBufferReceived, pos);
+          this._messageBufferReceived += chunkLen - pos;
           pos = chunkLen;
         }
       }
@@ -93,19 +96,23 @@ class DeserializeStream extends Transform  {
           ++pos;
         }
 
-        let bufLen = 0;
-        this._messageBuffer.forEach((bufferEntry) => {
-          bufLen += bufferEntry.length;
-        });
-
         // first 4 bytes of the message are a uint32 length field
-        if (chunkLen - pos >= 4 - bufLen) {
-          this._messageBuffer.push(chunk.slice(pos, pos + 4 - bufLen));
-          const buffer = Buffer.concat(this._messageBuffer, 4);
-          this._messageLen = buffer.readUInt32LE(0);
-          pos += 4 - bufLen;
+        if (chunkLen - pos >= 4 - this._messageSizeBufferReceived) {
+          chunk.copy(this._messageSizeBuffer, this._messageSizeBufferReceived,
+            pos, pos + 4 - this._messageSizeBufferReceived);
 
-          this._messageBuffer = []
+          this._messageLen = this._messageSizeBuffer.readUInt32LE(0);
+          pos += 4 - this._messageSizeBufferReceived;
+          this._messageSizeBufferReceived = 4;
+
+          // We've now completely received the 4 bytes of the length.
+
+          // do we need to grow the buffer?
+          if (this._messageLen > this._messageBuffer.length) {
+            this._messageBuffer = Buffer.allocUnsafe(this._messageLen);
+          }
+
+          this._messageBufferReceived = 0;
           // if its an empty message, there won't be any bytes left and message
           // will never be emitted -- handle that case here
           if (this._messageLen === 0 && pos === chunkLen) {
@@ -117,7 +124,9 @@ class DeserializeStream extends Transform  {
         }
         else {
           // the length field is split on a chunk
-          this._messageBuffer.push(chunk.slice(pos));
+          chunk.copy(this._messageSizeBuffer, this._messageSizeBufferReceived,
+            pos, pos + 4 - this._messageSizeBufferReceived);
+          this._messageSizeBufferReceived = chunkLen;
           pos = chunkLen;
         }
       }


### PR DESCRIPTION
- Using the `onread` option (see https://nodejs.org/docs/latest-v20.x/api/net.html#new-netsocketoptions)
  - This seems to avoid a buffer copy and hence speeds up deserialization of received ROS messages